### PR TITLE
Make use of overlay for composing haskell env for examples

### DIFF
--- a/examples/HROOT/flake.lock
+++ b/examples/HROOT/flake.lock
@@ -1,0 +1,118 @@
+{
+  "nodes": {
+    "HROOT": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651370590,
+        "narHash": "sha256-VHjPebuKt582KD9u/YDkNVQs/IsCZvtvChqg8K10M7Y=",
+        "owner": "wavewave",
+        "repo": "HROOT",
+        "rev": "80dcacab62486274a726e3661dd7a0e9180e72de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "HROOT",
+        "type": "github"
+      }
+    },
+    "fficxx": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651445996,
+        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
+        "owner": "wavewave",
+        "repo": "fficxx",
+        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "0.6",
+        "repo": "fficxx",
+        "type": "github"
+      }
+    },
+    "fficxx-projects": {
+      "inputs": {
+        "HROOT": "HROOT",
+        "fficxx": "fficxx",
+        "hgdal": "hgdal",
+        "hs-ogdf": "hs-ogdf",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1651542432,
+        "narHash": "sha256-9M+I3q/wFiloqFeqPw+ChmeQOwdWKrvj+4t9ggbo0cQ=",
+        "owner": "wavewave",
+        "repo": "fficxx-projects",
+        "rev": "be3b3c69c1cee5c3f4cdcca368bf0ab880f96173",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "overlay",
+        "repo": "fficxx-projects",
+        "type": "github"
+      }
+    },
+    "hgdal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1581209885,
+        "narHash": "sha256-8ibb8BZn0rlt6bdSxUytFECUJjglE/SvHnq7olJ4dV4=",
+        "owner": "wavewave",
+        "repo": "hgdal",
+        "rev": "f3af34d9e46cdd10a2fece49c9d807f844839708",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "hgdal",
+        "type": "github"
+      }
+    },
+    "hs-ogdf": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1580819174,
+        "narHash": "sha256-DhQE9xnBLtquOv6XrC+t3MPbSyWm8YBTc1cvCbrwvuo=",
+        "owner": "wavewave",
+        "repo": "hs-ogdf",
+        "rev": "2e385e12d59b2d432b54f6ff607e7b3b5f6d4366",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "hs-ogdf",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-20.03",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fficxx-projects": "fficxx-projects"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/HROOT/flake.nix
+++ b/examples/HROOT/flake.nix
@@ -1,19 +1,21 @@
 {
   description = "HROOT examples";
   inputs = {
-    fficxx-projects = {
-      url = "../.."; # "github:wavewave/fficxx-projects/master";
-    };
+    fficxx-projects = { url = "github:wavewave/fficxx-projects/master"; };
 
   };
   outputs = { self, fficxx-projects }:
-    let pkgs = fficxx-projects.inputs.nixpkgs.legacyPackages.x86_64-linux;
+    let
+      pkgs = import (fficxx-projects.inputs.nixpkgs) {
+        overlays = [ fficxx-projects.overlay ];
+        system = "x86_64-linux";
+        config = { allowBroken = true; };
+      };
 
     in {
       devShell.x86_64-linux = with pkgs;
         let
-          hsenv =
-            fficxx-projects.legacyPackages.x86_64-linux.haskellPackages.ghcWithPackages
+          hsenv = pkgs.haskellPackages.ghcWithPackages
             (p: with p; [ cabal-install HROOT monad-loops ]);
         in mkShell {
           buildInputs = [ hsenv ];

--- a/examples/OGDF/flake.lock
+++ b/examples/OGDF/flake.lock
@@ -1,0 +1,118 @@
+{
+  "nodes": {
+    "HROOT": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651370590,
+        "narHash": "sha256-VHjPebuKt582KD9u/YDkNVQs/IsCZvtvChqg8K10M7Y=",
+        "owner": "wavewave",
+        "repo": "HROOT",
+        "rev": "80dcacab62486274a726e3661dd7a0e9180e72de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "HROOT",
+        "type": "github"
+      }
+    },
+    "fficxx": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651445996,
+        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
+        "owner": "wavewave",
+        "repo": "fficxx",
+        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "0.6",
+        "repo": "fficxx",
+        "type": "github"
+      }
+    },
+    "fficxx-projects": {
+      "inputs": {
+        "HROOT": "HROOT",
+        "fficxx": "fficxx",
+        "hgdal": "hgdal",
+        "hs-ogdf": "hs-ogdf",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1651542432,
+        "narHash": "sha256-9M+I3q/wFiloqFeqPw+ChmeQOwdWKrvj+4t9ggbo0cQ=",
+        "owner": "wavewave",
+        "repo": "fficxx-projects",
+        "rev": "be3b3c69c1cee5c3f4cdcca368bf0ab880f96173",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "overlay",
+        "repo": "fficxx-projects",
+        "type": "github"
+      }
+    },
+    "hgdal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1581209885,
+        "narHash": "sha256-8ibb8BZn0rlt6bdSxUytFECUJjglE/SvHnq7olJ4dV4=",
+        "owner": "wavewave",
+        "repo": "hgdal",
+        "rev": "f3af34d9e46cdd10a2fece49c9d807f844839708",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "hgdal",
+        "type": "github"
+      }
+    },
+    "hs-ogdf": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1580819174,
+        "narHash": "sha256-DhQE9xnBLtquOv6XrC+t3MPbSyWm8YBTc1cvCbrwvuo=",
+        "owner": "wavewave",
+        "repo": "hs-ogdf",
+        "rev": "2e385e12d59b2d432b54f6ff607e7b3b5f6d4366",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "hs-ogdf",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-20.03",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fficxx-projects": "fficxx-projects"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/OGDF/flake.nix
+++ b/examples/OGDF/flake.nix
@@ -1,19 +1,21 @@
 {
   description = "hgdal examples";
   inputs = {
-    fficxx-projects = {
-      url = "../.."; # "github:wavewave/fficxx-projects/master";
-    };
+    fficxx-projects = { url = "github:wavewave/fficxx-projects/master"; };
 
   };
   outputs = { self, fficxx-projects }:
-    let pkgs = fficxx-projects.inputs.nixpkgs.legacyPackages.x86_64-linux;
+    let
+      pkgs = import (fficxx-projects.inputs.nixpkgs) {
+        overlays = [ fficxx-projects.overlay ];
+        system = "x86_64-linux";
+        config = { allowBroken = true; };
+      };
 
     in {
       devShell.x86_64-linux = with pkgs;
         let
-          hsenv =
-            fficxx-projects.legacyPackages.x86_64-linux.haskellPackages.ghcWithPackages
+          hsenv = pkgs.haskellPackages.ghcWithPackages
             (p: with p; [ cabal-install OGDF formatting monad-loops ]);
         in mkShell {
           buildInputs = [ hsenv ];

--- a/examples/hgdal/flake.lock
+++ b/examples/hgdal/flake.lock
@@ -1,0 +1,118 @@
+{
+  "nodes": {
+    "HROOT": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651370590,
+        "narHash": "sha256-VHjPebuKt582KD9u/YDkNVQs/IsCZvtvChqg8K10M7Y=",
+        "owner": "wavewave",
+        "repo": "HROOT",
+        "rev": "80dcacab62486274a726e3661dd7a0e9180e72de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "HROOT",
+        "type": "github"
+      }
+    },
+    "fficxx": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651445996,
+        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
+        "owner": "wavewave",
+        "repo": "fficxx",
+        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "0.6",
+        "repo": "fficxx",
+        "type": "github"
+      }
+    },
+    "fficxx-projects": {
+      "inputs": {
+        "HROOT": "HROOT",
+        "fficxx": "fficxx",
+        "hgdal": "hgdal",
+        "hs-ogdf": "hs-ogdf",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1651542432,
+        "narHash": "sha256-9M+I3q/wFiloqFeqPw+ChmeQOwdWKrvj+4t9ggbo0cQ=",
+        "owner": "wavewave",
+        "repo": "fficxx-projects",
+        "rev": "be3b3c69c1cee5c3f4cdcca368bf0ab880f96173",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "overlay",
+        "repo": "fficxx-projects",
+        "type": "github"
+      }
+    },
+    "hgdal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1581209885,
+        "narHash": "sha256-8ibb8BZn0rlt6bdSxUytFECUJjglE/SvHnq7olJ4dV4=",
+        "owner": "wavewave",
+        "repo": "hgdal",
+        "rev": "f3af34d9e46cdd10a2fece49c9d807f844839708",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "hgdal",
+        "type": "github"
+      }
+    },
+    "hs-ogdf": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1580819174,
+        "narHash": "sha256-DhQE9xnBLtquOv6XrC+t3MPbSyWm8YBTc1cvCbrwvuo=",
+        "owner": "wavewave",
+        "repo": "hs-ogdf",
+        "rev": "2e385e12d59b2d432b54f6ff607e7b3b5f6d4366",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "master",
+        "repo": "hs-ogdf",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-20.03",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fficxx-projects": "fficxx-projects"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/hgdal/flake.nix
+++ b/examples/hgdal/flake.nix
@@ -1,19 +1,21 @@
 {
   description = "hgdal examples";
   inputs = {
-    fficxx-projects = {
-      url = "../.."; # "github:wavewave/fficxx-projects/master";
-    };
+    fficxx-projects = { url = "github:wavewave/fficxx-projects/master"; };
 
   };
   outputs = { self, fficxx-projects }:
-    let pkgs = fficxx-projects.inputs.nixpkgs.legacyPackages.x86_64-linux;
+    let
+      pkgs = import (fficxx-projects.inputs.nixpkgs) {
+        overlays = [ fficxx-projects.overlay ];
+        system = "x86_64-linux";
+        config = { allowBroken = true; };
+      };
 
     in {
       devShell.x86_64-linux = with pkgs;
         let
-          hsenv =
-            fficxx-projects.legacyPackages.x86_64-linux.haskellPackages.ghcWithPackages
+          hsenv = pkgs.haskellPackages.ghcWithPackages
             (p: with p; [ cabal-install hgdal monad-loops ]);
         in mkShell {
           buildInputs = [ hsenv ];


### PR DESCRIPTION
Environments for examples testing HROOT, hgdal and OGDF should
be constructed in terms of overlay so that users can later
extend the environment with their own project in a composable
way.