### PR TITLE
fficxx as flake. overlay composition

### DIFF
--- a/examples/HROOT/flake.lock
+++ b/examples/HROOT/flake.lock
@@ -18,42 +18,57 @@
       }
     },
     "fficxx": {
-      "flake": false,
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1651445996,
-        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
-        "owner": "wavewave",
-        "repo": "fficxx",
-        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
-        "type": "github"
+        "lastModified": 1651631669,
+        "narHash": "sha256-BdNHDse/RnTU6zLsNVrrqGvOX9ZN/X+vn+SKv6Xq1fQ=",
+        "type": "git",
+        "url": "file:///home/wavewave/repo/src/fficxx"
       },
       "original": {
-        "owner": "wavewave",
-        "ref": "0.6",
-        "repo": "fficxx",
-        "type": "github"
+        "type": "git",
+        "url": "file:///home/wavewave/repo/src/fficxx"
       }
     },
     "fficxx-projects": {
       "inputs": {
         "HROOT": "HROOT",
-        "fficxx": "fficxx",
+        "fficxx": "fficxx_2",
         "hgdal": "hgdal",
         "hs-ogdf": "hs-ogdf",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1651545538,
-        "narHash": "sha256-2YIAXFMe6dgkr0GRv0w+H7EA28iowm2Vr2/sqIWV258=",
+        "lastModified": 1651545715,
+        "narHash": "sha256-Gji8nJHLqCKx1wWZWaRVMo6msb4DFRkc4X6MD0GRbP0=",
         "owner": "wavewave",
         "repo": "fficxx-projects",
-        "rev": "333e2562be35439987b6062bb8d0e056244dc7ed",
+        "rev": "ede0179c836f9081314a66759545e22187703160",
         "type": "github"
       },
       "original": {
         "owner": "wavewave",
         "ref": "master",
         "repo": "fficxx-projects",
+        "type": "github"
+      }
+    },
+    "fficxx_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651690367,
+        "narHash": "sha256-BdNHDse/RnTU6zLsNVrrqGvOX9ZN/X+vn+SKv6Xq1fQ=",
+        "owner": "wavewave",
+        "repo": "fficxx",
+        "rev": "388966e43f10a1f7370f61d1ab12a818804adede",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "0.6",
+        "repo": "fficxx",
         "type": "github"
       }
     },
@@ -107,8 +122,25 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-20.03",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "fficxx": "fficxx",
         "fficxx-projects": "fficxx-projects"
       }
     }

--- a/examples/HROOT/flake.nix
+++ b/examples/HROOT/flake.nix
@@ -1,13 +1,13 @@
 {
   description = "HROOT examples";
   inputs = {
+    fficxx = { url = "/home/wavewave/repo/src/fficxx"; };
     fficxx-projects = { url = "github:wavewave/fficxx-projects/master"; };
-
   };
-  outputs = { self, fficxx-projects }:
+  outputs = { self, fficxx, fficxx-projects }:
     let
       pkgs = import (fficxx-projects.inputs.nixpkgs) {
-        overlays = [ fficxx-projects.overlay ];
+        overlays = [ fficxx.overlay fficxx-projects.overlay ];
         system = "x86_64-linux";
         config = { allowBroken = true; };
       };
@@ -16,7 +16,7 @@
       devShell.x86_64-linux = with pkgs;
         let
           hsenv = pkgs.haskellPackages.ghcWithPackages
-            (p: with p; [ cabal-install HROOT monad-loops ]);
+            (p: [ p.cabal-install p.HROOT p.monad-loops ]);
         in mkShell {
           buildInputs = [ hsenv ];
           shellHook = "";

--- a/examples/OGDF/flake.lock
+++ b/examples/OGDF/flake.lock
@@ -18,29 +18,30 @@
       }
     },
     "fficxx": {
-      "flake": false,
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1651445996,
-        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
-        "owner": "wavewave",
-        "repo": "fficxx",
-        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
-        "type": "github"
+        "lastModified": 1651690427,
+        "narHash": "sha256-YLLznRPmzF7iTsFBwDKErCiwOs4jKbx9xp7JGsG3Lr8=",
+        "ref": "master",
+        "rev": "6ed85bc925e9901cde72d473110761d62feb6d4b",
+        "revCount": 1008,
+        "type": "git",
+        "url": "file:///home/wavewave/repo/src/fficxx"
       },
       "original": {
-        "owner": "wavewave",
-        "ref": "0.6",
-        "repo": "fficxx",
-        "type": "github"
+        "type": "git",
+        "url": "file:///home/wavewave/repo/src/fficxx"
       }
     },
     "fficxx-projects": {
       "inputs": {
         "HROOT": "HROOT",
-        "fficxx": "fficxx",
+        "fficxx": "fficxx_2",
         "hgdal": "hgdal",
         "hs-ogdf": "hs-ogdf",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1651545538,
@@ -54,6 +55,23 @@
         "owner": "wavewave",
         "ref": "master",
         "repo": "fficxx-projects",
+        "type": "github"
+      }
+    },
+    "fficxx_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651445996,
+        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
+        "owner": "wavewave",
+        "repo": "fficxx",
+        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "0.6",
+        "repo": "fficxx",
         "type": "github"
       }
     },
@@ -107,8 +125,25 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-20.03",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "fficxx": "fficxx",
         "fficxx-projects": "fficxx-projects"
       }
     }

--- a/examples/OGDF/flake.nix
+++ b/examples/OGDF/flake.nix
@@ -1,13 +1,13 @@
 {
   description = "hgdal examples";
   inputs = {
+    fficxx = { url = "/home/wavewave/repo/src/fficxx"; };
     fficxx-projects = { url = "github:wavewave/fficxx-projects/master"; };
-
   };
-  outputs = { self, fficxx-projects }:
+  outputs = { self, fficxx, fficxx-projects }:
     let
       pkgs = import (fficxx-projects.inputs.nixpkgs) {
-        overlays = [ fficxx-projects.overlay ];
+        overlays = [ fficxx.overlay fficxx-projects.overlay ];
         system = "x86_64-linux";
         config = { allowBroken = true; };
       };
@@ -16,7 +16,7 @@
       devShell.x86_64-linux = with pkgs;
         let
           hsenv = pkgs.haskellPackages.ghcWithPackages
-            (p: with p; [ cabal-install OGDF formatting monad-loops ]);
+            (p: [ p.cabal-install p.OGDF p.formatting p.monad-loops ]);
         in mkShell {
           buildInputs = [ hsenv ];
           shellHook = "";

--- a/examples/hgdal/flake.lock
+++ b/examples/hgdal/flake.lock
@@ -18,29 +18,30 @@
       }
     },
     "fficxx": {
-      "flake": false,
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1651445996,
-        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
-        "owner": "wavewave",
-        "repo": "fficxx",
-        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
-        "type": "github"
+        "lastModified": 1651690427,
+        "narHash": "sha256-YLLznRPmzF7iTsFBwDKErCiwOs4jKbx9xp7JGsG3Lr8=",
+        "ref": "master",
+        "rev": "6ed85bc925e9901cde72d473110761d62feb6d4b",
+        "revCount": 1008,
+        "type": "git",
+        "url": "file:///home/wavewave/repo/src/fficxx"
       },
       "original": {
-        "owner": "wavewave",
-        "ref": "0.6",
-        "repo": "fficxx",
-        "type": "github"
+        "type": "git",
+        "url": "file:///home/wavewave/repo/src/fficxx"
       }
     },
     "fficxx-projects": {
       "inputs": {
         "HROOT": "HROOT",
-        "fficxx": "fficxx",
+        "fficxx": "fficxx_2",
         "hgdal": "hgdal",
         "hs-ogdf": "hs-ogdf",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1651545538,
@@ -54,6 +55,23 @@
         "owner": "wavewave",
         "ref": "master",
         "repo": "fficxx-projects",
+        "type": "github"
+      }
+    },
+    "fficxx_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651445996,
+        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
+        "owner": "wavewave",
+        "repo": "fficxx",
+        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "0.6",
+        "repo": "fficxx",
         "type": "github"
       }
     },
@@ -107,8 +125,25 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-20.03",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "fficxx": "fficxx",
         "fficxx-projects": "fficxx-projects"
       }
     }

--- a/examples/hgdal/flake.nix
+++ b/examples/hgdal/flake.nix
@@ -1,13 +1,13 @@
 {
   description = "hgdal examples";
   inputs = {
+    fficxx = { url = "/home/wavewave/repo/src/fficxx"; };
     fficxx-projects = { url = "github:wavewave/fficxx-projects/master"; };
-
   };
-  outputs = { self, fficxx-projects }:
+  outputs = { self, fficxx, fficxx-projects }:
     let
       pkgs = import (fficxx-projects.inputs.nixpkgs) {
-        overlays = [ fficxx-projects.overlay ];
+        overlays = [ fficxx.overlay fficxx-projects.overlay ];
         system = "x86_64-linux";
         config = { allowBroken = true; };
       };
@@ -16,7 +16,7 @@
       devShell.x86_64-linux = with pkgs;
         let
           hsenv = pkgs.haskellPackages.ghcWithPackages
-            (p: with p; [ cabal-install hgdal monad-loops ]);
+            (p: [ p.cabal-install p.hgdal p.monad-loops ]);
         in mkShell {
           buildInputs = [ hsenv ];
           shellHook = "";

--- a/flake.lock
+++ b/flake.lock
@@ -18,13 +18,17 @@
       }
     },
     "fficxx": {
-      "flake": false,
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1651445996,
-        "narHash": "sha256-7eyPL7kD+XiWl6xPLtZUq9X21Y+9CF6P+5rx2tmw1Mk=",
+        "lastModified": 1651690367,
+        "narHash": "sha256-BdNHDse/RnTU6zLsNVrrqGvOX9ZN/X+vn+SKv6Xq1fQ=",
         "owner": "wavewave",
         "repo": "fficxx",
-        "rev": "98ce51453a2060b2545d50f9690a65e645aa71c2",
+        "rev": "388966e43f10a1f7370f61d1ab12a818804adede",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-20.03";
     fficxx = {
       url = "github:wavewave/fficxx/0.6";
-      flake = false;
+      inputs.nixpkgs.follows = "nixpkgs";
     };
     HROOT = {
       url = "github:wavewave/HROOT/master";
@@ -22,33 +22,15 @@
   };
   outputs = { self, nixpkgs, fficxx, HROOT, hgdal, hs-ogdf }:
     let
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-
-      haskellPackages = pkgs.haskell.packages.ghc865;
-      newHaskellPackages0 = haskellPackages.override {
-        overrides = self: super: {
-          "fficxx-runtime" =
-            self.callCabal2nix "fficxx-runtime" (fficxx + "/fficxx-runtime")
-            { };
-          "fficxx" = self.callCabal2nix "fficxx" (fficxx + "/fficxx") { };
-        };
-      };
-
-      stdcxxSrc = import (fficxx + "/stdcxx-gen/gen.nix") {
-        inherit (pkgs) stdenv;
-        haskellPackages = newHaskellPackages0;
+      pkgs = import nixpkgs {
+        overlays = [ fficxx.overlay ];
+        system = "x86_64-linux";
       };
 
       ogdf = pkgs.callPackage (hs-ogdf + "/ogdf") { };
 
       finalHaskellOverlay = self: super:
-        {
-          "fficxx-runtime" =
-            self.callCabal2nix "fficxx-runtime" (fficxx + "/fficxx-runtime")
-            { };
-          "fficxx" = self.callCabal2nix "fficxx" (fficxx + "/fficxx") { };
-          "stdcxx" = self.callCabal2nix "stdcxx" stdcxxSrc { };
-        } // (import HROOT {
+        (import HROOT {
           inherit pkgs;
           fficxxSrc = fficxx;
         } self super) // (import hgdal {
@@ -59,10 +41,7 @@
           fficxxSrc = fficxx;
         } self super);
 
-      newHaskellPackages = haskellPackages.override {
-        overrides = finalHaskellOverlay;
-
-      };
+      newHaskellPackages = pkgs.haskellPackages.extend finalHaskellOverlay;
 
       mkEnv = pkgname:
         let
@@ -77,24 +56,31 @@
     in {
       packages.x86_64-linux = {
         inherit ogdf;
+        stdcxx = pkgs.haskellPackages.stdcxx;
+
         inherit (newHaskellPackages)
-          fficxx fficxx-runtime stdcxx HROOT HROOT-core HROOT-graf HROOT-hist
-          HROOT-io HROOT-math HROOT-net HROOT-tree HROOT-RooFit
-          HROOT-RooFit-RooStats hgdal OGDF;
+          HROOT HROOT-core HROOT-graf HROOT-hist HROOT-io HROOT-math HROOT-net
+          HROOT-tree HROOT-RooFit HROOT-RooFit-RooStats hgdal OGDF;
         inherit HROOT-env hgdal-env OGDF-env;
 
       };
 
+      # see these issues and discussions:
+      # - https://github.com/NixOS/nixpkgs/issues/16394
+      # - https://github.com/NixOS/nixpkgs/issues/25887
+      # - https://github.com/NixOS/nixpkgs/issues/26561
+      # - https://discourse.nixos.org/t/nix-haskell-development-2020/6170
       overlay = final: prev: {
-        haskellPackages = prev.haskell.packages.ghc865.override {
-          overrides = finalHaskellOverlay;
-        };
+        haskellPackages = prev.haskellPackages.override (old: {
+          overrides = final.lib.composeExtensions (old.overrides or (_: _: { }))
+            finalHaskellOverlay;
+        });
       };
 
       devShell.x86_64-linux = with pkgs;
         let
-          hsenv = haskell.packages.ghc865.ghcWithPackages
-            (p: with p; [ cabal-install ]);
+          hsenv = haskellPackages.ghcWithPackages
+            (p: [ p.cabal-install p.fficxx p.fficxx-runtime p.stdcxx ]);
         in mkShell {
           buildInputs = [ hsenv ];
           shellHook = "";

--- a/flake.nix
+++ b/flake.nix
@@ -56,11 +56,10 @@
     in {
       packages.x86_64-linux = {
         inherit ogdf;
-        stdcxx = pkgs.haskellPackages.stdcxx;
-
         inherit (newHaskellPackages)
-          HROOT HROOT-core HROOT-graf HROOT-hist HROOT-io HROOT-math HROOT-net
-          HROOT-tree HROOT-RooFit HROOT-RooFit-RooStats hgdal OGDF;
+          fficxx-runtime fficxx stdcxx HROOT HROOT-core HROOT-graf HROOT-hist
+          HROOT-io HROOT-math HROOT-net HROOT-tree HROOT-RooFit
+          HROOT-RooFit-RooStats hgdal OGDF;
         inherit HROOT-env hgdal-env OGDF-env;
 
       };


### PR DESCRIPTION
fficxx is converted to nix flake package, and it is providing overlay. 
Therefore, the overlay part from fficxx (fficxx, fficxx-runtime, stdcxx) is now deleted from fficxx-projects flake. 
In the examples, the environment is constructed as a composition of overlays from fficxx and fficxx-projects.